### PR TITLE
Exposed getTokenPayload() function in the main interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ authenticate(provider, redirect, userData)
 signup(displayName, email, password)
 getMe()
 isAuthenticated()
+getTokenPayload()
 unlink(provider)
 ```
 Login is used for the local authentication strategy (email + password). Authenticate is for social media authentication. Authenticate is also used for linking a social media account to an existing account.

--- a/src/authService.js
+++ b/src/authService.js
@@ -28,14 +28,18 @@ export class AuthService  {
 		return this.auth.isAuthenticated();
 	};
 
+	getTokenPayload(){
+		return this.auth.getPayload();
+	};
+
 	signup(displayName, email, password){
-		var signupUrl = this.auth.getSignupUrl();		
+		var signupUrl = this.auth.getSignupUrl();
 		var content;
 		if (typeof arguments[0] === 'object') {
 			content = arguments[0];
 		} else {
 			content = {'displayName': displayName,'email': email, 'password':password};
-		}		
+		}
 		return this.http.createRequest(signupUrl)
 			.asPost()
 			.withContent(content)
@@ -92,9 +96,9 @@ export class AuthService  {
 			return response;
 		});
 	};
-	
+
 	unlink(provider) {
-		var unlinkUrl =  this.config.baseUrl 
+		var unlinkUrl =  this.config.baseUrl
 		? authUtils.joinUrl(this.config.baseUrl, this.config.unlinkUrl) : this.config.unlinkUrl;
 
 		if (this.config.unlinkMethod === 'get') {


### PR DESCRIPTION
As we discussed in issue https://github.com/paulvanbladel/aurelia-auth/issues/29, this PR exposes the getPayload() function in authorization.js as getTokenPayload() in the main interface (located in authService.js).

I also updated the README.md file to show the newly exposed function. 