### PR TITLE
Simpe hack / fix to temporarily make aurelia-auth support oidc

### DIFF
--- a/src/oAuth2.js
+++ b/src/oAuth2.js
@@ -51,8 +51,11 @@ export class OAuth2 {
       var self = this;
       return openPopup
       .then((oauthData) => {
-        if (self.defaults.responseType === 'token') {
-            return oauthData;
+        if (self.defaults.responseType === 'token' ||
+                    self.defaults.responseType === 'id_token%20token' ||                   
+                    self.defaults.responseType === 'token%20id_token' 
+                    ) {
+                    return oauthData;
         }
         if (oauthData.state && oauthData.state !== self.storage.get(stateName)) {
             return Promise.reject('OAuth 2.0 state parameter mismatch.');


### PR DESCRIPTION
OpenId connect (oidc) servers may mandate that you give the openid
scope to get profile claims, and then also mandate an 'id_token' or
combined 'id_token token' response type to alloe the openid scope.

This quick hack enables the oAuth2 provider to handle scenarios with
'id_token token' in addition to the existing 'token'  response type,
to enable an aurelia client to use the proper implicit flow
authentication.
(Consider this a band-aid while working on a more extensive oidc featureset, ref paulvanbladel/aurelia-auth#28)