### PR TITLE
Authentication Bugfix (replacing ALL '-' to '+' and '_' to '/')

### DIFF
--- a/src/authentication.js
+++ b/src/authentication.js
@@ -39,7 +39,7 @@ export class Authentication{
 
     if (token && token.split('.').length === 3) {
       var base64Url = token.split('.')[1];
-      var base64 = base64Url.replace('-', '+').replace('_', '/');
+      var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
       return JSON.parse(decodeURIComponent(escape(window.atob(base64))));
     }
   };
@@ -91,7 +91,7 @@ export class Authentication{
     if (token) {
       if (token.split('.').length === 3) {
         var base64Url = token.split('.')[1];
-        var base64 = base64Url.replace('-', '+').replace('_', '/');
+        var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
         var exp = JSON.parse(window.atob(base64)).exp;
         if (exp) {
           return Math.round(new Date().getTime() / 1000) <= exp;


### PR DESCRIPTION
base64 string is not correctly decoded

".replace('-', '+')" replaces only the first '-' to '+' and NOT all