### PR TITLE
aligning calls to aurelia pre-beta

### DIFF
--- a/src/authorizeStep.js
+++ b/src/authorizeStep.js
@@ -12,13 +12,13 @@ export class AuthorizeStep {
     var isLoggedIn =  this.auth.isAuthenticated();
     var loginRoute = this.auth.getLoginRoute();
 
-    if (routingContext.nextInstructions.some(i => i.config.auth)) {
+    if (routingContext.getAllInstructions().some(i => i.config.auth)) {
       if (!isLoggedIn) {
         console.log("login route : " + loginRoute);
         return next.cancel(new Redirect(loginRoute));
       }
     }
-    else if (isLoggedIn && routingContext.nextInstructions.some(i => i.fragment) == loginRoute) {
+    else if (isLoggedIn && routingContext.getAllInstructions().some(i => i.fragment) == loginRoute) {
       var loginRedirect = this.auth.getLoginRedirect();
       return next.cancel(new Redirect(loginRedirect));
     }


### PR DESCRIPTION
http://blog.durandal.io/2015/11/10/aurelia-pre-beta-release/

Router Pipeline steps now receive the NavigationInstruction instead of the NavigationContext. Pipeline steps should use instruction.getAllInstructions() and instruction.getAllPreviousInstructions() instead of context.nextInstructions and context.currentInstructions, respectively, to inspect current and previous instructions.