### PR TITLE
Update/dependencies

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,83 +15,12 @@ System.config({
   },
 
   map: {
-    "aurelia-fetch-client": "github:aurelia/fetch-client@0.4.0",
-    "aurelia-framework": "github:aurelia/framework@0.18.0",
-    "aurelia-http-client": "github:aurelia/http-client@0.13.0",
-    "aurelia-router": "github:aurelia/router@0.14.1",
-    "babel": "npm:babel-core@5.8.23",
-    "babel-runtime": "npm:babel-runtime@5.8.20",
-    "core-js": "npm:core-js@0.9.18",
-    "github:aurelia/binding@0.11.4": {
-      "aurelia-metadata": "github:aurelia/metadata@0.10.1",
-      "aurelia-pal": "github:aurelia/pal@0.3.0",
-      "aurelia-task-queue": "github:aurelia/task-queue@0.9.0",
-      "core-js": "npm:core-js@1.2.6"
-    },
-    "github:aurelia/dependency-injection@0.12.1": {
-      "aurelia-logging": "github:aurelia/logging@0.9.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.10.1",
-      "aurelia-pal": "github:aurelia/pal@0.3.0",
-      "core-js": "npm:core-js@1.2.6"
-    },
-    "github:aurelia/event-aggregator@0.10.0": {
-      "aurelia-logging": "github:aurelia/logging@0.9.0"
-    },
-    "github:aurelia/fetch-client@0.4.0": {
-      "core-js": "npm:core-js@1.2.6"
-    },
-    "github:aurelia/framework@0.18.0": {
-      "aurelia-binding": "github:aurelia/binding@0.11.4",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.12.1",
-      "aurelia-loader": "github:aurelia/loader@0.11.0",
-      "aurelia-logging": "github:aurelia/logging@0.9.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.10.1",
-      "aurelia-pal": "github:aurelia/pal@0.3.0",
-      "aurelia-path": "github:aurelia/path@0.11.0",
-      "aurelia-task-queue": "github:aurelia/task-queue@0.9.0",
-      "aurelia-templating": "github:aurelia/templating@0.17.5",
-      "core-js": "npm:core-js@1.2.6"
-    },
-    "github:aurelia/http-client@0.13.0": {
-      "aurelia-pal": "github:aurelia/pal@0.3.0",
-      "aurelia-path": "github:aurelia/path@0.11.0",
-      "core-js": "npm:core-js@1.2.6"
-    },
-    "github:aurelia/loader@0.11.0": {
-      "aurelia-metadata": "github:aurelia/metadata@0.10.1",
-      "aurelia-path": "github:aurelia/path@0.11.0"
-    },
-    "github:aurelia/metadata@0.10.1": {
-      "aurelia-pal": "github:aurelia/pal@0.3.0",
-      "core-js": "npm:core-js@1.2.6"
-    },
-    "github:aurelia/route-recognizer@0.9.0": {
-      "aurelia-path": "github:aurelia/path@0.11.0",
-      "core-js": "npm:core-js@1.2.6"
-    },
-    "github:aurelia/router@0.14.1": {
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.12.1",
-      "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.10.0",
-      "aurelia-history": "github:aurelia/history@0.9.0",
-      "aurelia-logging": "github:aurelia/logging@0.9.0",
-      "aurelia-path": "github:aurelia/path@0.11.0",
-      "aurelia-route-recognizer": "github:aurelia/route-recognizer@0.9.0",
-      "core-js": "npm:core-js@1.2.6"
-    },
-    "github:aurelia/task-queue@0.9.0": {
-      "aurelia-pal": "github:aurelia/pal@0.3.0"
-    },
-    "github:aurelia/templating@0.17.5": {
-      "aurelia-binding": "github:aurelia/binding@0.11.4",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.12.1",
-      "aurelia-loader": "github:aurelia/loader@0.11.0",
-      "aurelia-logging": "github:aurelia/logging@0.9.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.10.1",
-      "aurelia-pal": "github:aurelia/pal@0.3.0",
-      "aurelia-path": "github:aurelia/path@0.11.0",
-      "aurelia-task-queue": "github:aurelia/task-queue@0.9.0",
-      "core-js": "npm:core-js@1.2.6"
-    },
+    "aurelia-fetch-client": "npm:aurelia-fetch-client@1.0.0-beta.1",
+    "aurelia-framework": "npm:aurelia-framework@1.0.0-beta.1",
+    "aurelia-http-client": "npm:aurelia-http-client@1.0.0-beta.1",
+    "babel": "npm:babel-core@5.8.34",
+    "babel-runtime": "npm:babel-runtime@5.8.34",
+    "core-js": "npm:core-js@1.2.6",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },
@@ -107,13 +36,62 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:babel-runtime@5.8.20": {
-      "process": "github:jspm/nodelibs-process@0.1.2"
+    "npm:aurelia-binding@1.0.0-beta.1.0.1": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1",
+      "core-js": "npm:core-js@1.2.6"
     },
-    "npm:core-js@0.9.18": {
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.2",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    "npm:aurelia-dependency-injection@1.0.0-beta.1": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
+      "core-js": "npm:core-js@1.2.6"
+    },
+    "npm:aurelia-fetch-client@1.0.0-beta.1": {
+      "core-js": "npm:core-js@1.2.6"
+    },
+    "npm:aurelia-framework@1.0.0-beta.1": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.0.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1",
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1",
+      "aurelia-templating": "npm:aurelia-templating@1.0.0-beta.1",
+      "core-js": "npm:core-js@1.2.6"
+    },
+    "npm:aurelia-http-client@1.0.0-beta.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1",
+      "core-js": "npm:core-js@1.2.6"
+    },
+    "npm:aurelia-loader@1.0.0-beta.1": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1"
+    },
+    "npm:aurelia-metadata@1.0.0-beta.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
+      "core-js": "npm:core-js@1.2.6"
+    },
+    "npm:aurelia-task-queue@1.0.0-beta.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1"
+    },
+    "npm:aurelia-templating@1.0.0-beta.1": {
+      "aurelia-binding": "npm:aurelia-binding@1.0.0-beta.1.0.1",
+      "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1",
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1",
+      "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0-beta.1",
+      "core-js": "npm:core-js@1.2.6"
+    },
+    "npm:babel-runtime@5.8.34": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:core-js@1.2.6": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.11.3 (2015-11-17)
+* Updated dependencies for beta
+
 ### 0.11.2 (2015-11-17)
 * Updated dependencies.
 * Sync package.json version with git tags.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-auth",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Plugin for social media authentication and local authentication together with other authentication utilities",
   "main": "dist/system/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,18 +61,17 @@
       "lib": "dist/system"
     },
     "dependencies": {
-      "aurelia-fetch-client": "github:aurelia/fetch-client@^0.4.0",
-      "aurelia-framework": "github:aurelia/framework@^0.18.0",
-      "aurelia-http-client": "github:aurelia/http-client@^0.13.0",
-      "aurelia-router": "github:aurelia/router@^0.14.1"
+      "aurelia-fetch-client": "npm:aurelia-fetch-client@^1.0.0-beta.1",
+      "aurelia-framework": "npm:aurelia-framework@^1.0.0-beta.1",
+      "aurelia-http-client": "npm:aurelia-http-client@^1.0.0-beta.1"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^5.6.4",
       "babel-runtime": "npm:babel-runtime@^5.6.4",
-      "core-js": "npm:core-js@^0.9.4"
+      "core-js": "npm:core-js@^1.2.6"
     },
     "overrides": {
-      "npm:core-js@0.9.18": {
+      "npm:core-js@1.2.6": {
         "main": "client/shim.min"
       }
     }


### PR DESCRIPTION
Updated dependencies for the beta.

Dependencies moved to npm, meaning that a regular ol' update didn't do the trick.

**Note:** Dependencies are also more grouped now, so I was able to remove the router.