### PR TITLE
Adds Config for token property on response object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ export class App {
     this.router = router;
     this.fetchConfig = fetchConfig;
   }
-  
+
   activate(){
     this.fetchConfig.configure();
   }
 }
 ```
 
-## Configure Http Client 
+## Configure Http Client
 Allthough the Fetch Client is the preferred 'http client' for aurelia, there is also support for aurelia-http-client.
 The configuration of aurelia-http-client is similar to aurelia-fetch-client.
 In your aurelia app file, inject the `HttpClientConfig`.
@@ -282,6 +282,7 @@ Via the above mentioned configuration virtually all aspects of the authenticatio
   tokenRoot: false,
   tokenName: 'token',
   tokenPrefix: 'aurelia',
+  responseTokenProp: 'access_token',
   unlinkUrl: '/auth/unlink/',
   unlinkMethod: 'get',
   authHeader: 'Authorization',

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -48,7 +48,7 @@ export class Authentication {
   setToken(response, redirect) {
 
     var tokenName = this.tokenName;
-    var accessToken = response && response.access_token;
+    var accessToken = response && response[this.config.responseTokenProp];
     var token;
 
     if (accessToken) {

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -25,6 +25,7 @@ export class BaseConfig {
       tokenRoot: false,
       tokenName: 'token',
       tokenPrefix: 'aurelia',
+      responseTokenProp: 'access_token',
       unlinkUrl: '/auth/unlink/',
       unlinkMethod: 'get',
       authHeader: 'Authorization',


### PR DESCRIPTION
Hello @paulvanbladel
 
When using the Implicit Grant Type with OpenID Connect the JWT gets
return as `id_token`; the plug-in expects `access_token` to be the JWT.
See paulvanbladel/aurelia-auth#53.

This change is a work around in order to allow a user to set the property of the
response for use as the token if its something other than `access_token`.

This should not be a breaking change.

Example config for an OpenID Connect provider using the Implicit flow (thanks @devscott!):
```JavaScript
class Config {
  constructor() {
    this.baseUrl = this.CurrentHost;
    this.loginRedirect =  '/#',
    this.responseTokenProp = 'id_token';
    this.providers = {
      OpenIDConnect: {
        name: 'OpenIDConnect',
        authorizationEndpoint: 'https://foo.bar/authorize',
        redirectUri: this.CurrentHost,
        scope: [
          'profile',
          'email',
          'uma_authorization',
          'uma_protection',
          'user_name'
        ],
        scopePrefix: 'openid',
        scopeDelimiter: ' ',
        requiredUrlParams: ['scope', 'nonce', 'state'],
        optionalUrlParams: ['display'],
        responseType: 'id_token%20token',
        display: 'popup',
        state: '',
        type: '2.0',
        clientId: 'YourSPA',
        nonce: this.Nonce,
        popupOptions: {
          width: 1020,
          height: 618
        }
      }
    }
  }

  get Nonce() {
    return encodeURIComponent(
      ((Date.now() + Math.random()) * Math.random())
      .toString()
      .replace(".", "")
    );
  }

  get CurrentHost() {
    return window.location.origin || `${window.location.protocol}//${window.location.host}`
  }

}

export default new Config();
```