### PR TITLE
Redirect to initial URL after successful login

### DIFF
--- a/src/authentication.js
+++ b/src/authentication.js
@@ -16,7 +16,7 @@ export class Authentication {
   }
 
   getLoginRedirect() {
-    return this.config.loginRedirect;
+    return this.initialUrl || this.config.loginRedirect;
   }
 
   getLoginUrl() {
@@ -53,6 +53,10 @@ export class Authentication {
       }
     }
 
+  setInitialUrl(url) {
+    this.initialUrl = url;
+  }
+
   setToken(response, redirect) {
 
     var tokenName = this.tokenName;
@@ -81,7 +85,7 @@ export class Authentication {
     this.storage.set(tokenName, token);
 
     if (this.config.loginRedirect && !redirect) {
-      window.location.href = this.config.loginRedirect;
+      window.location.href = this.getLoginRedirect();
     } else if (redirect && authUtils.isString(redirect)) {
       window.location.href = window.encodeURI(redirect);
     }

--- a/src/authorizeStep.js
+++ b/src/authorizeStep.js
@@ -14,6 +14,7 @@ export class AuthorizeStep {
     if (routingContext.getAllInstructions().some(i => i.config.auth)) {
       if (!isLoggedIn) {
         console.log("login route : " + loginRoute);
+        this.auth.setInitialUrl(window.location.href);
         return next.cancel(new Redirect(loginRoute));
       }
     } else if (isLoggedIn && routingContext.getAllInstructions().some(i => i.fragment) == loginRoute) {

--- a/src/authorizeStep.js
+++ b/src/authorizeStep.js
@@ -13,7 +13,6 @@ export class AuthorizeStep {
 
     if (routingContext.getAllInstructions().some(i => i.config.auth)) {
       if (!isLoggedIn) {
-        console.log("login route : " + loginRoute);
         this.auth.setInitialUrl(window.location.href);
         return next.cancel(new Redirect(loginRoute));
       }


### PR DESCRIPTION
#90 Redirect back to initial page after the successful login 
When authorize steps redirects to login page, it sets current url to the `auth` instance. Then, after the login `auth` instance redirects to this URL instead of default URL in config file.