### PR TITLE
Error response statuses still return response, but the promise is rejected

### DIFF
--- a/dist/amd/authService.js
+++ b/dist/amd/authService.js
@@ -147,7 +147,7 @@ define(['exports', 'aurelia-framework', 'aurelia-fetch-client', './authenticatio
     if (response.status >= 200 && response.status < 300) {
       return Promise.resolve(response);
     } else {
-      return Promise.reject(new Error(response.statusText));
+      return Promise.reject(response);
     }
   }
 

--- a/dist/commonjs/authService.js
+++ b/dist/commonjs/authService.js
@@ -160,7 +160,7 @@ function status(response) {
   if (response.status >= 200 && response.status < 300) {
     return Promise.resolve(response);
   } else {
-    return Promise.reject(new Error(response.statusText));
+    return Promise.reject(response);
   }
 }
 

--- a/dist/es6/authService.js
+++ b/dist/es6/authService.js
@@ -131,9 +131,9 @@ export class AuthService {
 
 function status(response) {
   if (response.status >= 200 && response.status < 300) {
-    return Promise.resolve(response)
+    return Promise.resolve(response);
   } else {
-    return Promise.reject(new Error(response.statusText))
+    return Promise.reject(response);
   }
 }
 

--- a/dist/system/authService.js
+++ b/dist/system/authService.js
@@ -11,7 +11,7 @@ System.register(['aurelia-framework', 'aurelia-fetch-client', './authentication'
     if (response.status >= 200 && response.status < 300) {
       return Promise.resolve(response);
     } else {
-      return Promise.reject(new Error(response.statusText));
+      return Promise.reject(response);
     }
   }
 

--- a/src/authService.js
+++ b/src/authService.js
@@ -131,9 +131,9 @@ export class AuthService {
 
 function status(response) {
   if (response.status >= 200 && response.status < 300) {
-    return Promise.resolve(response)
+    return Promise.resolve(response);
   } else {
-    return Promise.reject(new Error(response.statusText))
+    return Promise.reject(response);
   }
 }
 


### PR DESCRIPTION
Is there any reason why in case of erroneous response code you reject promise with new `Error`object? I found it problematic since in user code there is no way to find out what went wrong. Having response it is possible to read body or status code and decide what should be displayed or fixed.

I understand that you pass `statusText` from the response, but this is not enough information. Look at your sample application. In sign up you sent 409 code if email is already in database. What if you have also password strength validation then you should sent different status code (400 I guess). Then those are two different reasons of failure.

Also compatibility problem arise. according to https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/statusText statusText is a standard (still not much information in it), however when it comes to fetch: https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText it is not impemented in IE and Safari. Yeah probably fetch polyfill can fix it, but still not much information in it.
