### PR TITLE
Added content type header and stringified JSON in body

### DIFF
--- a/src/oAuth2.js
+++ b/src/oAuth2.js
@@ -113,7 +113,8 @@ export class OAuth2 {
 
     return this.http.fetch(exchangeForTokenUrl, {
       method: 'post',
-      body: json(data),
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      body: JSON.stringify(data),
       credentials: credentials
     })
       .then(authUtils.status)


### PR DESCRIPTION
The POST without the content type and stingfied body didn't work in IE 9