### PR TITLE
Events for authentication actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,17 @@ configure(){
 ```
 In the above example the customer route is only available for authenticated users.
 
+# Events
+
+At each step of authentication (login, logout, authenticate, signup, unlink), an event is published to Aurelia's event aggregator.
+The events published are as follows:
+
+* login: `auth:login`
+* logout: `auth:logout`
+* authenticate: `auth:authenticate`
+* signup: `auth:signup`
+* unlink: `auth:unlink`
+
 # Full configuration options.
 
 Via the above mentioned configuration virtually all aspects of the authentication process be tweaked:

--- a/config.js
+++ b/config.js
@@ -16,6 +16,7 @@ System.config({
 
   map: {
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
+    "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.2.1",
     "aurelia-fetch-client": "npm:aurelia-fetch-client@1.0.0-beta.1.2.0",
     "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.2.0",
     "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.1.0",
@@ -69,12 +70,12 @@ System.config({
       "util": "npm:util@0.10.3"
     },
     "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.0",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
     },
-    "npm:aurelia-event-aggregator@1.0.0-beta.1.2.0": {
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0"
+    "npm:aurelia-event-aggregator@1.0.0-beta.1.2.1": {
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1"
     },
     "npm:aurelia-metadata@1.0.0-beta.1.2.0": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.0"
@@ -90,9 +91,9 @@ System.config({
     },
     "npm:aurelia-router@1.0.0-beta.1.2.0": {
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.0",
-      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.2.0",
+      "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0-beta.1.2.1",
       "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.2.0",
-      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.0",
+      "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
       "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.0",
       "aurelia-route-recognizer": "npm:aurelia-route-recognizer@1.0.0-beta.1.2.0"
     },

--- a/dist/amd/aurelia-auth.d.ts
+++ b/dist/amd/aurelia-auth.d.ts
@@ -10,6 +10,9 @@ declare module 'aurelia-auth' {
   import {
     Redirect
   } from 'aurelia-router';
+  import {
+    EventAggregator
+  } from 'aurelia-event-aggregator';
   export function status(response: any): any;
   export function isDefined(value: any): any;
   export function camelCase(name: any): any;
@@ -87,7 +90,7 @@ declare module 'aurelia-auth' {
     buildQueryString(current: any): any;
   }
   export class AuthService {
-    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any);
+    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any, eventAggregator: any);
     getMe(): any;
     isAuthenticated(): any;
     getTokenPayload(): any;

--- a/dist/aurelia-auth.d.ts
+++ b/dist/aurelia-auth.d.ts
@@ -10,6 +10,9 @@ declare module 'aurelia-auth' {
   import {
     Redirect
   } from 'aurelia-router';
+  import {
+    EventAggregator
+  } from 'aurelia-event-aggregator';
   export function status(response: any): any;
   export function isDefined(value: any): any;
   export function camelCase(name: any): any;
@@ -87,7 +90,7 @@ declare module 'aurelia-auth' {
     buildQueryString(current: any): any;
   }
   export class AuthService {
-    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any);
+    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any, eventAggregator: any);
     getMe(): any;
     isAuthenticated(): any;
     getTokenPayload(): any;

--- a/dist/commonjs/aurelia-auth.d.ts
+++ b/dist/commonjs/aurelia-auth.d.ts
@@ -10,6 +10,9 @@ declare module 'aurelia-auth' {
   import {
     Redirect
   } from 'aurelia-router';
+  import {
+    EventAggregator
+  } from 'aurelia-event-aggregator';
   export function status(response: any): any;
   export function isDefined(value: any): any;
   export function camelCase(name: any): any;
@@ -87,7 +90,7 @@ declare module 'aurelia-auth' {
     buildQueryString(current: any): any;
   }
   export class AuthService {
-    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any);
+    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any, eventAggregator: any);
     getMe(): any;
     isAuthenticated(): any;
     getTokenPayload(): any;

--- a/dist/commonjs/auth-service.js
+++ b/dist/commonjs/auth-service.js
@@ -13,6 +13,8 @@ var _aureliaDependencyInjection = require('aurelia-dependency-injection');
 
 var _aureliaFetchClient = require('aurelia-fetch-client');
 
+var _aureliaEventAggregator = require('aurelia-event-aggregator');
+
 require('isomorphic-fetch');
 
 var _authentication = require('./authentication');
@@ -27,8 +29,8 @@ var _authUtilities = require('./auth-utilities');
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var AuthService = exports.AuthService = (_dec = (0, _aureliaDependencyInjection.inject)(_aureliaFetchClient.HttpClient, _authentication.Authentication, _oAuth.OAuth1, _oAuth2.OAuth2, _baseConfig.BaseConfig), _dec(_class = function () {
-  function AuthService(http, auth, oAuth1, oAuth2, config) {
+var AuthService = exports.AuthService = (_dec = (0, _aureliaDependencyInjection.inject)(_aureliaFetchClient.HttpClient, _authentication.Authentication, _oAuth.OAuth1, _oAuth2.OAuth2, _baseConfig.BaseConfig, _aureliaEventAggregator.EventAggregator), _dec(_class = function () {
+  function AuthService(http, auth, oAuth1, oAuth2, config, eventAggregator) {
     _classCallCheck(this, AuthService);
 
     this.http = http;
@@ -37,6 +39,7 @@ var AuthService = exports.AuthService = (_dec = (0, _aureliaDependencyInjection.
     this.oAuth2 = oAuth2;
     this.config = config.current;
     this.tokenInterceptor = auth.tokenInterceptor;
+    this.eventAggregator = eventAggregator;
   }
 
   AuthService.prototype.getMe = function getMe() {
@@ -76,6 +79,7 @@ var AuthService = exports.AuthService = (_dec = (0, _aureliaDependencyInjection.
       } else if (_this.config.signupRedirect) {
         window.location.href = _this.config.signupRedirect;
       }
+      _this.eventAggregator.publish('auth:signup', response);
       return response;
     });
   };
@@ -100,11 +104,13 @@ var AuthService = exports.AuthService = (_dec = (0, _aureliaDependencyInjection.
       body: typeof content === 'string' ? content : (0, _aureliaFetchClient.json)(content)
     }).then(_authUtilities.status).then(function (response) {
       _this2.auth.setToken(response);
+      _this2.eventAggregator.publish('auth:login', response);
       return response;
     });
   };
 
   AuthService.prototype.logout = function logout(redirectUri) {
+    this.eventAggregator.publish('auth:logout');
     return this.auth.logout(redirectUri);
   };
 
@@ -118,20 +124,29 @@ var AuthService = exports.AuthService = (_dec = (0, _aureliaDependencyInjection.
 
     return provider.open(this.config.providers[name], userData || {}).then(function (response) {
       _this3.auth.setToken(response, redirect);
+      _this3.eventAggregator.publish('auth:authenticate', response);
       return response;
     });
   };
 
   AuthService.prototype.unlink = function unlink(provider) {
+    var _this4 = this;
+
     var unlinkUrl = this.config.baseUrl ? (0, _authUtilities.joinUrl)(this.config.baseUrl, this.config.unlinkUrl) : this.config.unlinkUrl;
 
     if (this.config.unlinkMethod === 'get') {
-      return this.http.fetch(unlinkUrl + provider).then(_authUtilities.status);
+      return this.http.fetch(unlinkUrl + provider).then(_authUtilities.status).then(function (response) {
+        _this4.eventAggregator.publish('auth:unlink', response);
+        return response;
+      });
     } else if (this.config.unlinkMethod === 'post') {
       return this.http.fetch(unlinkUrl, {
         method: 'post',
         body: (0, _aureliaFetchClient.json)(provider)
-      }).then(_authUtilities.status);
+      }).then(_authUtilities.status).then(function (response) {
+        _this4.eventAggregator.publish('auth:unlink', response);
+        return response;
+      });
     }
   };
 

--- a/dist/es2015/aurelia-auth.d.ts
+++ b/dist/es2015/aurelia-auth.d.ts
@@ -10,6 +10,9 @@ declare module 'aurelia-auth' {
   import {
     Redirect
   } from 'aurelia-router';
+  import {
+    EventAggregator
+  } from 'aurelia-event-aggregator';
   export function status(response: any): any;
   export function isDefined(value: any): any;
   export function camelCase(name: any): any;
@@ -87,7 +90,7 @@ declare module 'aurelia-auth' {
     buildQueryString(current: any): any;
   }
   export class AuthService {
-    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any);
+    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any, eventAggregator: any);
     getMe(): any;
     isAuthenticated(): any;
     getTokenPayload(): any;

--- a/dist/system/aurelia-auth.d.ts
+++ b/dist/system/aurelia-auth.d.ts
@@ -10,6 +10,9 @@ declare module 'aurelia-auth' {
   import {
     Redirect
   } from 'aurelia-router';
+  import {
+    EventAggregator
+  } from 'aurelia-event-aggregator';
   export function status(response: any): any;
   export function isDefined(value: any): any;
   export function camelCase(name: any): any;
@@ -87,7 +90,7 @@ declare module 'aurelia-auth' {
     buildQueryString(current: any): any;
   }
   export class AuthService {
-    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any);
+    constructor(http: any, auth: any, oAuth1: any, oAuth2: any, config: any, eventAggregator: any);
     getMe(): any;
     isAuthenticated(): any;
     getTokenPayload(): any;

--- a/dist/system/aurelia-auth.js
+++ b/dist/system/aurelia-auth.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['./auth-service', './authorize-step', './auth-fetch-config', './base-config', './auth-filter'], function (_export, _context) {
+  "use strict";
+
   var AuthService, AuthorizeStep, FetchConfig, BaseConfig, AuthFilterValueConverter;
   return {
     setters: [function (_authService) {

--- a/dist/system/auth-fetch-config.js
+++ b/dist/system/auth-fetch-config.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['aurelia-dependency-injection', 'aurelia-fetch-client', 'isomorphic-fetch', './authentication'], function (_export, _context) {
+  "use strict";
+
   var inject, HttpClient, Authentication, _dec, _class, FetchConfig;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/system/auth-filter.js
+++ b/dist/system/auth-filter.js
@@ -1,6 +1,8 @@
 "use strict";
 
 System.register([], function (_export, _context) {
+  "use strict";
+
   var AuthFilterValueConverter;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/system/auth-utilities.js
+++ b/dist/system/auth-utilities.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register([], function (_export, _context) {
+  "use strict";
+
   var _typeof, slice;
 
   function setHashKey(obj, h) {

--- a/dist/system/authentication.js
+++ b/dist/system/authentication.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['aurelia-dependency-injection', './base-config', './storage', './auth-utilities'], function (_export, _context) {
+  "use strict";
+
   var inject, BaseConfig, Storage, joinUrl, isObject, isString, _createClass, _dec, _class, Authentication;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/system/authorize-step.js
+++ b/dist/system/authorize-step.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['aurelia-dependency-injection', 'aurelia-router', './authentication'], function (_export, _context) {
+  "use strict";
+
   var inject, Redirect, Authentication, _dec, _class, AuthorizeStep;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/system/base-config.js
+++ b/dist/system/base-config.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['./auth-utilities'], function (_export, _context) {
+  "use strict";
+
   var merge, _createClass, BaseConfig;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/system/oAuth1.js
+++ b/dist/system/oAuth1.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['aurelia-dependency-injection', './auth-utilities', './storage', './popup', './base-config', 'aurelia-fetch-client', 'isomorphic-fetch'], function (_export, _context) {
+  "use strict";
+
   var inject, extend, forEach, joinUrl, status, Storage, Popup, BaseConfig, HttpClient, json, _dec, _class, OAuth1;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/system/oAuth2.js
+++ b/dist/system/oAuth2.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['aurelia-dependency-injection', './auth-utilities', './storage', './popup', './base-config', './authentication', 'aurelia-fetch-client', 'isomorphic-fetch'], function (_export, _context) {
+  "use strict";
+
   var inject, extend, forEach, isFunction, isString, joinUrl, camelCase, status, Storage, Popup, BaseConfig, Authentication, HttpClient, json, _dec, _class, OAuth2;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/system/popup.js
+++ b/dist/system/popup.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['./auth-utilities', './base-config', 'aurelia-dependency-injection'], function (_export, _context) {
+  "use strict";
+
   var parseQueryString, extend, forEach, BaseConfig, inject, _dec, _class, Popup;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/system/storage.js
+++ b/dist/system/storage.js
@@ -1,6 +1,8 @@
 'use strict';
 
 System.register(['aurelia-dependency-injection', './base-config'], function (_export, _context) {
+  "use strict";
+
   var inject, BaseConfig, _dec, _class, Storage;
 
   function _classCallCheck(instance, Constructor) {

--- a/dist/temp/aurelia-auth.js
+++ b/dist/temp/aurelia-auth.js
@@ -34,6 +34,8 @@ var _aureliaFetchClient = require('aurelia-fetch-client');
 
 var _aureliaRouter = require('aurelia-router');
 
+var _aureliaEventAggregator = require('aurelia-event-aggregator');
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var slice = [].slice;
@@ -999,8 +1001,8 @@ var OAuth2 = exports.OAuth2 = (_dec7 = (0, _aureliaDependencyInjection.inject)(S
 
   return OAuth2;
 }()) || _class7);
-var AuthService = exports.AuthService = (_dec8 = (0, _aureliaDependencyInjection.inject)(_aureliaFetchClient.HttpClient, Authentication, OAuth1, OAuth2, BaseConfig), _dec8(_class8 = function () {
-  function AuthService(http, auth, oAuth1, oAuth2, config) {
+var AuthService = exports.AuthService = (_dec8 = (0, _aureliaDependencyInjection.inject)(_aureliaFetchClient.HttpClient, Authentication, OAuth1, OAuth2, BaseConfig, _aureliaEventAggregator.EventAggregator), _dec8(_class8 = function () {
+  function AuthService(http, auth, oAuth1, oAuth2, config, eventAggregator) {
     _classCallCheck(this, AuthService);
 
     this.http = http;
@@ -1009,6 +1011,7 @@ var AuthService = exports.AuthService = (_dec8 = (0, _aureliaDependencyInjection
     this.oAuth2 = oAuth2;
     this.config = config.current;
     this.tokenInterceptor = auth.tokenInterceptor;
+    this.eventAggregator = eventAggregator;
   }
 
   AuthService.prototype.getMe = function getMe() {
@@ -1048,6 +1051,7 @@ var AuthService = exports.AuthService = (_dec8 = (0, _aureliaDependencyInjection
       } else if (_this7.config.signupRedirect) {
         window.location.href = _this7.config.signupRedirect;
       }
+      _this7.eventAggregator.publish('auth:signup', response);
       return response;
     });
   };
@@ -1072,11 +1076,13 @@ var AuthService = exports.AuthService = (_dec8 = (0, _aureliaDependencyInjection
       body: typeof content === 'string' ? content : (0, _aureliaFetchClient.json)(content)
     }).then(status).then(function (response) {
       _this8.auth.setToken(response);
+      _this8.eventAggregator.publish('auth:login', response);
       return response;
     });
   };
 
   AuthService.prototype.logout = function logout(redirectUri) {
+    this.eventAggregator.publish('auth:logout');
     return this.auth.logout(redirectUri);
   };
 
@@ -1090,20 +1096,29 @@ var AuthService = exports.AuthService = (_dec8 = (0, _aureliaDependencyInjection
 
     return provider.open(this.config.providers[name], userData || {}).then(function (response) {
       _this9.auth.setToken(response, redirect);
+      _this9.eventAggregator.publish('auth:authenticate', response);
       return response;
     });
   };
 
   AuthService.prototype.unlink = function unlink(provider) {
+    var _this10 = this;
+
     var unlinkUrl = this.config.baseUrl ? joinUrl(this.config.baseUrl, this.config.unlinkUrl) : this.config.unlinkUrl;
 
     if (this.config.unlinkMethod === 'get') {
-      return this.http.fetch(unlinkUrl + provider).then(status);
+      return this.http.fetch(unlinkUrl + provider).then(status).then(function (response) {
+        _this10.eventAggregator.publish('auth:unlink', response);
+        return response;
+      });
     } else if (this.config.unlinkMethod === 'post') {
       return this.http.fetch(unlinkUrl, {
         method: 'post',
         body: (0, _aureliaFetchClient.json)(provider)
-      }).then(status);
+      }).then(status).then(function (response) {
+        _this10.eventAggregator.publish('auth:unlink', response);
+        return response;
+      });
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     },
     "dependencies": {
       "aurelia-dependency-injection": "1.0.0-beta.1.2.0",
+      "aurelia-event-aggregator": "^1.0.0-beta.1.2.1",
       "aurelia-fetch-client": "^1.0.0-beta.1.2.0",
       "aurelia-router": "^1.0.0-beta.1.2.0",
       "isomorphic-fetch": "^2.2.1"

--- a/src/auth-service.js
+++ b/src/auth-service.js
@@ -102,7 +102,7 @@ export class AuthService {
     return provider.open(this.config.providers[name], userData || {})
       .then((response) => {
         this.auth.setToken(response, redirect);
-        this.eventAggregator.publish('auth:authenticate', response)
+        this.eventAggregator.publish('auth:authenticate', response);
         return response;
       });
   }
@@ -116,8 +116,8 @@ export class AuthService {
       return this.http.fetch(unlinkUrl + provider)
         .then(status)
         .then(response => {
-            this.eventAggregator.publish('auth:unlink', response);
-            return response;
+          this.eventAggregator.publish('auth:unlink', response);
+          return response;
         });
     } else if (this.config.unlinkMethod === 'post') {
       return this.http.fetch(unlinkUrl, {
@@ -125,8 +125,8 @@ export class AuthService {
         body: json(provider)
       }).then(status)
       .then(response => {
-          this.eventAggregator.publish('auth:unlink', response);
-          return response;
+        this.eventAggregator.publish('auth:unlink', response);
+        return response;
       });
     }
   }


### PR DESCRIPTION
This PR uses Aurelia's event aggregator to publish events at each step of authentication (login, logout, authenticate, signup, unlink). This is useful in situations where part of the navbar (which would be separate from the login page) needs to be updated depending on the authentication (or lack thereof) of the user.