### PR TITLE
Expose setToken(response, redirect) from Authentication in AuthService

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ In the above example the customer route is only available for authenticated user
 
 ## Supplying token programmatically
 
-In case you would like to supply token programmatically instead of using login() functionality, use `setToken(token)`. You might need it to automatically log in use upon registration or on similar use cases.
+In case you would like to supply token programmatically instead of using login functionality, use `setToken(token)`. You might need it to automatically log in user upon registration or on similar use cases.
 
 # Events
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ getMe()
 isAuthenticated()
 getTokenPayload()
 unlink(provider)
+setToken(token)
 ```
 Login is used for the local authentication strategy (email + password). Authenticate is for social media authentication. Authenticate is also used for linking a social media account to an existing account.
 
@@ -393,6 +394,10 @@ configure(){
     }
 ```
 In the above example the customer route is only available for authenticated users.
+
+## Supplying token programmatically
+
+In case you would like to supply token programmatically instead of using login() functionality, use `setToken(token)`. You might need it to automatically log in use upon registration or on similar use cases.
 
 # Events
 

--- a/src/auth-service.js
+++ b/src/auth-service.js
@@ -33,6 +33,10 @@ export class AuthService {
     return this.auth.getPayload();
   }
 
+  setToken(token) {
+    this.auth.setToken(Object.defineProperty( {}, this.config.tokenName, { value: token } ));
+  }
+
   signup(displayName, email, password) {
     let signupUrl = this.auth.getSignupUrl();
     let content;


### PR DESCRIPTION
In Satellizer there is a method setToken(token) to set the token from the code. I use it to log in users automatically during signup process. Aurelia version lacked the support, so I added it. I guess other developers might also find it useful, especially when having used Satellizer for Angular.