### PR TITLE
Raise 'auth:logout' event after logging out not before

### DIFF
--- a/src/auth-service.js
+++ b/src/auth-service.js
@@ -92,8 +92,10 @@ export class AuthService {
   }
 
   logout(redirectUri) {
-    this.eventAggregator.publish('auth:logout');
-    return this.auth.logout(redirectUri);
+    return this.auth.logout(redirectUri)
+      .then(() => {
+        this.eventAggregator.publish('auth:logout');
+      });
   }
 
   authenticate(name, redirect, userData) {


### PR DESCRIPTION
The other auth: events are raised after successfully completing the action. 

auth:logout was being raised prior to logging out, which could cause some difficulties if a developer subscribed to the handler and checked the isAuthenticated() method.
