### PR TITLE
Add missing header in Fetch-Config issue #105 #107

### DIFF
--- a/src/auth-fetch-config.js
+++ b/src/auth-fetch-config.js
@@ -14,7 +14,8 @@ export class FetchConfig {
       httpConfig
         .withDefaults({
           headers: {
-            'Accept': 'application/json'
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
           }
         })
         .withInterceptor(this.auth.tokenInterceptor);


### PR DESCRIPTION
Add the missing Content-Type header, without this, the Twitter OAuth1
fails with Node Koa