### PR TITLE
Fix default headers (#105, #168)

### DIFF
--- a/src/auth-fetch-config.js
+++ b/src/auth-fetch-config.js
@@ -12,12 +12,6 @@ export class FetchConfig {
   configure() {
     this.httpClient.configure(httpConfig => {
       httpConfig
-        .withDefaults({
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-          }
-        })
         .withInterceptor(this.auth.tokenInterceptor);
     });
   }

--- a/src/auth-service.js
+++ b/src/auth-service.js
@@ -54,7 +54,7 @@ export class AuthService {
       method: 'post',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json' 
+        'Content-Type': 'application/json'
       },
       body: json(content)
     })
@@ -133,7 +133,7 @@ export class AuthService {
         method: 'post',
         headers: {
           'Accept': 'application/json',
-          'Content-Type': 'application/json' 
+          'Content-Type': 'application/json'
         },
         body: json(provider)
       }).then(status)

--- a/src/auth-service.js
+++ b/src/auth-service.js
@@ -52,6 +52,10 @@ export class AuthService {
 
     return this.http.fetch(signupUrl, {
       method: 'post',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json' 
+      },
       body: json(content)
     })
       .then(status)
@@ -127,6 +131,10 @@ export class AuthService {
     } else if (this.config.unlinkMethod === 'post') {
       return this.http.fetch(unlinkUrl, {
         method: 'post',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json' 
+        },
         body: json(provider)
       }).then(status)
       .then(response => {

--- a/src/oAuth1.js
+++ b/src/oAuth1.js
@@ -63,6 +63,10 @@ export class OAuth1 {
 
     return this.http.fetch(exchangeForTokenUrl, {
       method: 'post',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json' 
+      },
       body: json(data),
       credentials: credentials
     }).then(status);

--- a/src/oAuth1.js
+++ b/src/oAuth1.js
@@ -65,7 +65,7 @@ export class OAuth1 {
       method: 'post',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json' 
+        'Content-Type': 'application/json'
       },
       body: json(data),
       credentials: credentials

--- a/src/oAuth2.js
+++ b/src/oAuth2.js
@@ -113,7 +113,7 @@ export class OAuth2 {
       method: 'post',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json' 
+        'Content-Type': 'application/json'
       },
       body: json(data),
       credentials: credentials

--- a/src/oAuth2.js
+++ b/src/oAuth2.js
@@ -111,6 +111,10 @@ export class OAuth2 {
 
     return this.http.fetch(exchangeForTokenUrl, {
       method: 'post',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json' 
+      },
       body: json(data),
       credentials: credentials
     }).then(status);


### PR DESCRIPTION
This pull requests reverts the behaviour introduced in #105 and #168 that broke all multipart requests by setting the default Content-Type header to 'application/json', preventing the client to automatically calculating multipart data boundary. 

This pull requests removes the default configuration in FetchConfig and instead, approaches the problem by explicitly setting the needed headers for each request in the library, so that the library does not interfere with host applications.
