### PR TITLE
Updated login method signature to add custom headers

### DIFF
--- a/dist/aurelia-auth.d.ts
+++ b/dist/aurelia-auth.d.ts
@@ -93,7 +93,7 @@ declare module 'aurelia-auth' {
     getTokenPayload(): any;
     setToken(token: any): any;
     signup(displayName: any, email: any, password: any): any;
-    login(email: any, password?: any): any;
+    login(email: any, password?: any, headers?: any): any;
     logout(redirectUri: any): any;
     authenticate(name: any, redirect: any, userData: any): any;
     unlink(provider: any): any;

--- a/src/auth-service.js
+++ b/src/auth-service.js
@@ -70,7 +70,7 @@ export class AuthService {
       });
   }
 
-  login(email, password) {
+  login(email, password, headers) {
     let loginUrl = this.auth.getLoginUrl();
     let content;
     if (typeof arguments[1] !== 'string') {
@@ -84,7 +84,7 @@ export class AuthService {
 
     return this.http.fetch(loginUrl, {
       method: 'post',
-      headers: typeof(content) === 'string' ? {'Content-Type': 'application/x-www-form-urlencoded'} : {},
+      headers: headers ? headers : (typeof(content) === 'string' ? {'Content-Type': 'application/x-www-form-urlencoded'} : {}),
       body: typeof(content) === 'string' ? content : json(content)
     })
       .then(status)


### PR DESCRIPTION
Updated **login** method signature in **auth-service.js**.
`login(email: any, password?: any, headers?: any): any;`
It will be helpful if anyone wants to add custom headers while making http request which was not feasible earlier.
